### PR TITLE
fix(playback): Autoplay is now disabled by default

### DIFF
--- a/src/js/Smooth.js
+++ b/src/js/Smooth.js
@@ -109,9 +109,9 @@ class Smooth extends Meister.MediaPlugin {
             }
         });
 
-
         return new Promise((resolve) => {
             this.mediaPlayer = new MediaPlayer();
+            this.mediaPlayer.setAutoPlay(false);
             this.mediaPlayer.init(this.meister.playerPlugin.mediaElement);
             this.mediaPlayer.load({
                 url: item.src,


### PR DESCRIPTION
The Hasplayer default was true, but since we expect the Core to take
care of auotplaying we set it to false on the plugin level.